### PR TITLE
Fix: Ensure Gradle Wrapper Files Are Tracked in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,6 @@ unlinked_spec.ds
 **/android/**/gradle-wrapper.jar
 .gradle/
 **/android/captures/
-**/android/gradlew
-**/android/gradlew.bat
 **/android/local.properties
 **/android/**/GeneratedPluginRegistrant.java
 **/android/key.properties


### PR DESCRIPTION
### 📋 **Description:**

**What was changed:**
- Removed `gradlew` and `gradlew.bat` from `.gitignore` to ensure the Gradle wrapper files are tracked by Git.
- This change ensures that **GitHub Actions** can find the necessary Gradle wrapper files to execute build tasks correctly.

**Why is this change necessary?**
- The Gradle wrapper (`gradlew`) is required for Fastlane and CI pipelines to build the Android project.
- The files were being ignored by `.gitignore`, causing errors in GitHub Actions, where the workflow could not locate the `gradlew` file during the build process.

---

### 🛠 **Steps to Test:**
1. Ensure that the Gradle wrapper files (`gradlew` and `gradlew.bat`) are now tracked in the repository.
2. Trigger a build by pushing to the `main` or `develop` branch.
3. Verify that the GitHub Actions workflow for **internal APK build** now completes successfully without errors related to the Gradle wrapper.

