### PR TITLE
fix: release the camera when exiting Live (Vision) screen

### DIFF
--- a/lib/features/vision/providers/vision_provider.dart
+++ b/lib/features/vision/providers/vision_provider.dart
@@ -186,13 +186,20 @@ class VisionController extends StateNotifier<VisionState> {
       );
     }
     _avatar.react(AvatarEmotion.neutral, activity: AvatarActivity.idle);
+    if (cam == null) return;
+    // Stop the image stream and release the camera INDEPENDENTLY: if
+    // stopImageStream throws (a common race when the screen is torn down),
+    // dispose() must still run — that's what frees the hardware and clears the
+    // "camera in use" indicator.
     try {
-      if (cam != null) {
-        if (cam.value.isStreamingImages) await cam.stopImageStream();
-        await cam.dispose();
-      }
+      if (cam.value.isStreamingImages) await cam.stopImageStream();
     } catch (e) {
-      AppLogger.w('Camera stop error: $e', tag: 'Vision');
+      AppLogger.w('stopImageStream failed: $e', tag: 'Vision');
+    }
+    try {
+      await cam.dispose();
+    } catch (e) {
+      AppLogger.w('camera dispose failed: $e', tag: 'Vision');
     }
   }
 


### PR DESCRIPTION
Fixes #9

## Problem
After leaving the Live/Vision screen, the OS "camera in use" indicator stayed on — the camera was never released.

## Root cause
`VisionController.stop()` wrapped both `stopImageStream()` and `dispose()` in a single `try/catch`:

```dart
try {
  if (cam.value.isStreamingImages) await cam.stopImageStream();
  await cam.dispose(); // skipped if the line above throws
} catch (e) { ... }
```

On screen teardown `stopImageStream()` can throw (e.g. a frame is mid-flight / the stream already stopped). When it did, the `catch` swallowed it and **`cam.dispose()` never ran**, so the camera hardware was never freed.

## Fix
Guard `stopImageStream()` and `dispose()` independently so `dispose()` always runs even if stopping the stream fails. `dispose()` is what releases the hardware and clears the indicator.

The screen already calls `stop()` from its `State.dispose()`, so exiting the screen now reliably turns the camera off.

## Test plan
- [ ] Open Home → Live, confirm the camera indicator turns on.
- [ ] Press back to exit the screen → the camera indicator turns **off** within a moment.
- [ ] Re-enter Live → camera works again (start/stop is repeatable).
- [ ] Flip camera (front/back) still works (also uses stop()/start()).

## Notes
- `flutter analyze` is clean.
- Scoped to the camera-release bug; app-lifecycle (pause on background) could be a follow-up.