### PR TITLE
fix: reliably release camera on exit + stabilize hands-free mic

### DIFF
--- a/lib/features/vision/presentation/screens/vision_screen.dart
+++ b/lib/features/vision/presentation/screens/vision_screen.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../../core/providers/settings_provider.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/theme/app_text_styles.dart';
 import '../../../avatar/models/avatar_emotion.dart';
@@ -14,11 +15,13 @@ import '../../../voice/presentation/widgets/voice_wave.dart';
 import '../../../voice/providers/voice_provider.dart';
 import '../../providers/vision_provider.dart';
 
-/// "Live" companion mode — fully hands-free. Only Vyra's animated face shows;
-/// the front camera stays on for awareness (never displayed). The mic listens
-/// continuously: it auto-pauses while she speaks or thinks (so she never hears
-/// herself) and resumes the moment she's done. She also talks first and keeps
-/// the conversation going. Tap the mic to mute / unmute hands-free.
+/// "Live" companion mode — turn-based hands-free.
+///
+/// Native speech recognizers can't truly stay on forever (they endpoint per
+/// utterance), so instead of brute-force restarting (which caused the mic to
+/// flap on/off) we take turns: the mic opens for the user's turn, ends when
+/// they pause, Vyra replies, then the mic auto-reopens for the next turn. After
+/// a lull she re-engages a few times, then waits. Tap the mic to pause/resume.
 class VisionScreen extends ConsumerStatefulWidget {
   const VisionScreen({super.key});
 
@@ -29,17 +32,16 @@ class VisionScreen extends ConsumerStatefulWidget {
 class _VisionScreenState extends ConsumerState<VisionScreen>
     with WidgetsBindingObserver {
   final math.Random _rng = math.Random();
-  String _caption = "Hey! I'm right here — just start talking.";
-  bool _handsFree = true;
-  bool _spoke = false;
+  String _caption = "Hey! I'm right here — let's talk.";
+  bool _handsFree = true; // false = paused/muted by the user
   bool _foreground = true;
+  bool _spoke = false;
+  int _consecutiveNudges = 0;
   DateTime _lastSmileReact = DateTime.fromMillisecondsSinceEpoch(0);
   DateTime _lastInteraction = DateTime.now();
   DateTime _lastListenStart = DateTime.fromMillisecondsSinceEpoch(0);
   Timer? _tick;
 
-  // Captured once so teardown never depends on `ref` (which is fragile in
-  // dispose / lifecycle callbacks).
   VisionController? _visionCtrl;
   VoiceController? _voiceCtrl;
 
@@ -62,8 +64,9 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
     "I'm curious — what's something you're into these days?",
     'Got anything fun coming up?',
     'Want to hear a joke, or shall we just chat?',
-    'If you could do anything right now, what would it be?',
   ];
+
+  bool get _ttsOn => ref.read(settingsProvider).ttsEnabled;
 
   @override
   void initState() {
@@ -72,15 +75,11 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
     _voiceCtrl = ref.read(voiceControllerProvider.notifier);
     WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _visionCtrl?.start(); // awareness only
+      _visionCtrl?.start(); // awareness only — preview never shown
       ref.read(avatarControllerProvider.notifier).react(AvatarEmotion.caring);
-
-      // Break the ice herself, in case the camera doesn't spot a face.
-      Future.delayed(const Duration(seconds: 4), () {
-        if (mounted && !_spoke) _speakOpener();
-      });
-      // Drives continuous listening + gentle re-engagement.
-      _tick = Timer.periodic(const Duration(milliseconds: 800), (_) => _onTick());
+      // Make her break the ice almost immediately (then she opens the mic).
+      _lastInteraction = DateTime.now().subtract(const Duration(seconds: 13));
+      _tick = Timer.periodic(const Duration(seconds: 2), (_) => _onTick());
     });
   }
 
@@ -88,14 +87,11 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
   void dispose() {
     _tick?.cancel();
     WidgetsBinding.instance.removeObserver(this);
-    // Use the captured notifiers (not ref) so teardown reliably releases the
-    // camera + mic when the screen is closed.
     _voiceCtrl?.stopListening();
     _visionCtrl?.stop();
     super.dispose();
   }
 
-  // Release the camera + mic when the app is backgrounded; restart on resume.
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
@@ -108,36 +104,42 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
     }
   }
 
+  // Proactive re-engagement only — NOT a listening restart (that's what caused
+  // the flapping). After a lull she asks something, which then reopens the mic.
   void _onTick() {
-    if (!mounted || !_foreground) return;
+    if (!mounted || !_foreground || !_handsFree) return;
     final voice = ref.read(voiceControllerProvider);
     final responding = ref.read(chatControllerProvider).isResponding;
-
-    // She's neither speaking nor thinking right now.
-    final free = !voice.isSpeaking && !responding;
-
-    // Re-engage after a stretch of silence — a friend doesn't just go quiet.
-    if (free &&
-        DateTime.now().difference(_lastInteraction) >=
-            const Duration(seconds: 22)) {
+    if (voice.isListening || voice.isSpeaking || responding) return;
+    if (_consecutiveNudges >= 3) return; // she's said enough; wait for the user
+    if (DateTime.now().difference(_lastInteraction) >=
+        const Duration(seconds: 15)) {
+      _consecutiveNudges++;
       _speakOpener();
-      return;
-    }
-
-    // Keep the mic open whenever it should be — but throttle restarts so the
-    // recognizer can't rapidly flap on/off between sessions.
-    if (_handsFree &&
-        free &&
-        voice.sttAvailable &&
-        !voice.isListening &&
-        DateTime.now().difference(_lastListenStart) >
-            const Duration(milliseconds: 1500)) {
-      _lastListenStart = DateTime.now();
-      ref.read(voiceControllerProvider.notifier).startListening(onFinal: _onHeard);
     }
   }
 
+  // Open the mic for the user's turn (guarded + throttled).
+  void _armListening() {
+    if (!mounted || !_handsFree || !_foreground) return;
+    final voice = ref.read(voiceControllerProvider);
+    final responding = ref.read(chatControllerProvider).isResponding;
+    if (voice.isListening ||
+        voice.isSpeaking ||
+        responding ||
+        !voice.sttAvailable) {
+      return;
+    }
+    if (DateTime.now().difference(_lastListenStart) <
+        const Duration(milliseconds: 800)) {
+      return;
+    }
+    _lastListenStart = DateTime.now();
+    ref.read(voiceControllerProvider.notifier).startListening(onFinal: _onHeard);
+  }
+
   void _onHeard(String text) {
+    _consecutiveNudges = 0;
     _lastInteraction = DateTime.now();
     ref.read(chatControllerProvider.notifier).send(text);
   }
@@ -156,12 +158,16 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
     _lastInteraction = DateTime.now();
     ref.read(avatarControllerProvider.notifier).react(emotion);
     ref.read(voiceControllerProvider.notifier).speak(line);
+    // If TTS is off there's no "speak complete" event to reopen the mic.
+    if (!_ttsOn) {
+      Future.delayed(const Duration(milliseconds: 700), _armListening);
+    }
   }
 
   void _onPresenceChange(VisionState? prev, VisionState next) {
     final wasPresent = (prev?.faceCount ?? 0) > 0;
     final isPresent = next.faceCount > 0;
-    if (!wasPresent && isPresent) {
+    if (!wasPresent && isPresent && !_spoke) {
       _say(_greetings[_rng.nextInt(_greetings.length)], AvatarEmotion.happy);
       return;
     }
@@ -174,24 +180,39 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
     }
   }
 
-  void _toggleHandsFree() {
-    setState(() => _handsFree = !_handsFree);
-    if (!_handsFree) {
+  // When Vyra finishes speaking, it's the user's turn → reopen the mic.
+  void _onVoiceChange(VoiceState? prev, VoiceState next) {
+    if ((prev?.isSpeaking ?? false) && !next.isSpeaking) {
+      _armListening();
+    }
+  }
+
+  void _toggleMic() {
+    if (_handsFree) {
+      setState(() => _handsFree = false);
       ref.read(voiceControllerProvider.notifier).stopListening();
     } else {
+      setState(() => _handsFree = true);
+      _consecutiveNudges = 0;
       _lastInteraction = DateTime.now();
+      _armListening();
     }
   }
 
   @override
   Widget build(BuildContext context) {
     ref.listen<VisionState>(visionControllerProvider, _onPresenceChange);
+    ref.listen<VoiceState>(voiceControllerProvider, _onVoiceChange);
     ref.listen(chatControllerProvider.select((s) => s.messages.length), (_, __) {
       final msgs = ref.read(chatControllerProvider).messages;
       for (final m in msgs.reversed) {
         if (!m.isUser) {
           _lastInteraction = DateTime.now();
           if (mounted) setState(() => _caption = m.text);
+          // With TTS off, reopen the mic after her (silent) reply.
+          if (!_ttsOn) {
+            Future.delayed(const Duration(milliseconds: 600), _armListening);
+          }
           break;
         }
       }
@@ -204,27 +225,26 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
     final amplitude =
         ref.watch(avatarControllerProvider.select((s) => s.amplitude));
 
-    // Treat hands-free "listening mode" as a steady state (she's neither
-    // speaking nor thinking) so the UI doesn't flicker as the recognizer
-    // restarts between utterances.
-    final inListeningMode = _handsFree && !voice.isSpeaking && !responding;
-
     final seesYou = vision.faceCount > 0;
-    final status = vision.error != null
-        ? "I can't see, but I'm all ears"
-        : seesYou
-            ? (vision.smileProbability > 0.6
-                ? 'Love that smile 😊'
-                : 'I can see you 👀')
-            : "I'm right here";
+    final status = !_handsFree
+        ? 'Paused'
+        : voice.isListening
+            ? 'Listening…'
+            : voice.isSpeaking
+                ? 'Speaking…'
+                : responding
+                    ? 'Thinking…'
+                    : (seesYou ? 'I can see you 👀' : "I'm here");
 
     final hint = !_handsFree
-        ? 'Muted · tap to go hands-free'
-        : voice.isSpeaking
-            ? 'Speaking…'
-            : responding
-                ? 'Thinking…'
-                : 'Listening… just talk';
+        ? 'Tap to talk hands-free'
+        : voice.isListening
+            ? 'Go ahead, I’m listening…'
+            : voice.isSpeaking
+                ? 'Speaking…'
+                : responding
+                    ? 'Thinking…'
+                    : 'Tap if I don’t catch you';
 
     return Scaffold(
       body: Container(
@@ -247,12 +267,12 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
               const Spacer(),
               const VyraAvatarLive(size: 280),
               const SizedBox(height: 10),
-              _StatusChip(text: status, active: seesYou),
+              _StatusChip(text: status, active: voice.isListening || seesYou),
               const SizedBox(height: 18),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 24),
                 child: _CaptionBox(
-                  listening: inListeningMode,
+                  listening: voice.isListening,
                   partial: voice.partialText,
                   caption: _caption,
                   amplitude: amplitude,
@@ -261,8 +281,8 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
               const Spacer(),
               _MicButton(
                 handsFree: _handsFree,
-                listening: inListeningMode,
-                onTap: _toggleHandsFree,
+                listening: voice.isListening,
+                onTap: _toggleMic,
               ),
               const SizedBox(height: 12),
               Text(hint, style: AppTextStyles.caption),
@@ -378,7 +398,7 @@ class _MicButton extends StatelessWidget {
               ? [
                   BoxShadow(
                     color: accent.withValues(alpha: 0.45),
-                    blurRadius: listening ? 30 : 18,
+                    blurRadius: listening ? 30 : 16,
                     spreadRadius: listening ? 4 : 1,
                   ),
                 ]

--- a/lib/features/vision/presentation/screens/vision_screen.dart
+++ b/lib/features/vision/presentation/screens/vision_screen.dart
@@ -33,6 +33,7 @@ class _VisionScreenState extends ConsumerState<VisionScreen> {
   bool _spoke = false;
   DateTime _lastSmileReact = DateTime.fromMillisecondsSinceEpoch(0);
   DateTime _lastInteraction = DateTime.now();
+  DateTime _lastListenStart = DateTime.fromMillisecondsSinceEpoch(0);
   Timer? _tick;
 
   static const _greetings = [
@@ -97,8 +98,15 @@ class _VisionScreenState extends ConsumerState<VisionScreen> {
       return;
     }
 
-    // Keep the mic open whenever it should be.
-    if (_handsFree && free && voice.sttAvailable && !voice.isListening) {
+    // Keep the mic open whenever it should be — but throttle restarts so the
+    // recognizer can't rapidly flap on/off between sessions.
+    if (_handsFree &&
+        free &&
+        voice.sttAvailable &&
+        !voice.isListening &&
+        DateTime.now().difference(_lastListenStart) >
+            const Duration(milliseconds: 1500)) {
+      _lastListenStart = DateTime.now();
       ref.read(voiceControllerProvider.notifier).startListening(onFinal: _onHeard);
     }
   }
@@ -165,8 +173,15 @@ class _VisionScreenState extends ConsumerState<VisionScreen> {
 
     final vision = ref.watch(visionControllerProvider);
     final voice = ref.watch(voiceControllerProvider);
+    final responding =
+        ref.watch(chatControllerProvider.select((s) => s.isResponding));
     final amplitude =
         ref.watch(avatarControllerProvider.select((s) => s.amplitude));
+
+    // Treat hands-free "listening mode" as a steady state (she's neither
+    // speaking nor thinking) so the UI doesn't flicker as the recognizer
+    // restarts between utterances.
+    final inListeningMode = _handsFree && !voice.isSpeaking && !responding;
 
     final seesYou = vision.faceCount > 0;
     final status = vision.error != null
@@ -179,9 +194,11 @@ class _VisionScreenState extends ConsumerState<VisionScreen> {
 
     final hint = !_handsFree
         ? 'Muted · tap to go hands-free'
-        : voice.isListening
-            ? 'Listening… just talk'
-            : 'Hands-free on · tap to mute';
+        : voice.isSpeaking
+            ? 'Speaking…'
+            : responding
+                ? 'Thinking…'
+                : 'Listening… just talk';
 
     return Scaffold(
       body: Container(
@@ -209,7 +226,7 @@ class _VisionScreenState extends ConsumerState<VisionScreen> {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 24),
                 child: _CaptionBox(
-                  listening: _handsFree && voice.isListening,
+                  listening: inListeningMode,
                   partial: voice.partialText,
                   caption: _caption,
                   amplitude: amplitude,
@@ -218,7 +235,7 @@ class _VisionScreenState extends ConsumerState<VisionScreen> {
               const Spacer(),
               _MicButton(
                 handsFree: _handsFree,
-                listening: voice.isListening,
+                listening: inListeningMode,
                 onTap: _toggleHandsFree,
               ),
               const SizedBox(height: 12),

--- a/lib/features/vision/presentation/screens/vision_screen.dart
+++ b/lib/features/vision/presentation/screens/vision_screen.dart
@@ -26,15 +26,22 @@ class VisionScreen extends ConsumerStatefulWidget {
   ConsumerState<VisionScreen> createState() => _VisionScreenState();
 }
 
-class _VisionScreenState extends ConsumerState<VisionScreen> {
+class _VisionScreenState extends ConsumerState<VisionScreen>
+    with WidgetsBindingObserver {
   final math.Random _rng = math.Random();
   String _caption = "Hey! I'm right here — just start talking.";
   bool _handsFree = true;
   bool _spoke = false;
+  bool _foreground = true;
   DateTime _lastSmileReact = DateTime.fromMillisecondsSinceEpoch(0);
   DateTime _lastInteraction = DateTime.now();
   DateTime _lastListenStart = DateTime.fromMillisecondsSinceEpoch(0);
   Timer? _tick;
+
+  // Captured once so teardown never depends on `ref` (which is fragile in
+  // dispose / lifecycle callbacks).
+  VisionController? _visionCtrl;
+  VoiceController? _voiceCtrl;
 
   static const _greetings = [
     'Hey, there you are! 😊',
@@ -61,8 +68,11 @@ class _VisionScreenState extends ConsumerState<VisionScreen> {
   @override
   void initState() {
     super.initState();
+    _visionCtrl = ref.read(visionControllerProvider.notifier);
+    _voiceCtrl = ref.read(voiceControllerProvider.notifier);
+    WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(visionControllerProvider.notifier).start(); // awareness only
+      _visionCtrl?.start(); // awareness only
       ref.read(avatarControllerProvider.notifier).react(AvatarEmotion.caring);
 
       // Break the ice herself, in case the camera doesn't spot a face.
@@ -77,13 +87,29 @@ class _VisionScreenState extends ConsumerState<VisionScreen> {
   @override
   void dispose() {
     _tick?.cancel();
-    ref.read(voiceControllerProvider.notifier).stopListening();
-    ref.read(visionControllerProvider.notifier).stop();
+    WidgetsBinding.instance.removeObserver(this);
+    // Use the captured notifiers (not ref) so teardown reliably releases the
+    // camera + mic when the screen is closed.
+    _voiceCtrl?.stopListening();
+    _visionCtrl?.stop();
     super.dispose();
   }
 
+  // Release the camera + mic when the app is backgrounded; restart on resume.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _foreground = true;
+      if (mounted) _visionCtrl?.start();
+    } else {
+      _foreground = false;
+      _voiceCtrl?.stopListening();
+      _visionCtrl?.stop();
+    }
+  }
+
   void _onTick() {
-    if (!mounted) return;
+    if (!mounted || !_foreground) return;
     final voice = ref.read(voiceControllerProvider);
     final responding = ref.read(chatControllerProvider).isResponding;
 

--- a/lib/features/vision/providers/vision_provider.dart
+++ b/lib/features/vision/providers/vision_provider.dart
@@ -208,14 +208,16 @@ class VisionController extends StateNotifier<VisionState> {
         faceRects: const [],
       );
     }
-    _avatar.react(AvatarEmotion.neutral, activity: AvatarActivity.idle);
-    if (cam == null) return;
-    // Stop the image stream and release the camera INDEPENDENTLY: if
-    // stopImageStream throws (a common race when the screen is torn down),
-    // dispose() must still run — that's what frees the hardware and clears the
-    // "camera in use" indicator.
     try {
-      if (cam.value.isStreamingImages) await cam.stopImageStream();
+      _avatar.react(AvatarEmotion.neutral, activity: AvatarActivity.idle);
+    } catch (_) {}
+    if (cam == null) return;
+    // Always attempt to stop the stream (the isStreamingImages flag can be
+    // stale, and disposing while a stream is live can leave the camera open),
+    // then always dispose — dispose() is what frees the hardware and clears the
+    // "camera in use" indicator. Both are guarded independently.
+    try {
+      await cam.stopImageStream();
     } catch (e) {
       AppLogger.w('stopImageStream failed: $e', tag: 'Vision');
     }

--- a/lib/features/vision/providers/vision_provider.dart
+++ b/lib/features/vision/providers/vision_provider.dart
@@ -78,6 +78,11 @@ class VisionController extends StateNotifier<VisionState> {
   CameraLensDirection _lens = CameraLensDirection.front;
   AvatarEmotion _lastEmotion = AvatarEmotion.neutral;
 
+  // Incremented on every start()/stop(); lets an in-flight async start() detect
+  // that it was superseded (e.g. the screen was left) and tear its camera down
+  // instead of leaking it.
+  int _session = 0;
+
   CameraController? get cameraController => _camera;
   FaceDetectionService get _service =>
       _ref.read(faceDetectionServiceProvider);
@@ -86,9 +91,12 @@ class VisionController extends StateNotifier<VisionState> {
 
   Future<void> start() async {
     if (state.active || state.initializing) return;
+    final session = ++_session;
     state = state.copyWith(initializing: true, clearError: true);
+    CameraController? controller;
     try {
       final cameras = await availableCameras();
+      if (session != _session) return; // superseded by stop()/start()
       if (cameras.isEmpty) {
         state = state.copyWith(
             initializing: false, error: 'No camera available on this device.');
@@ -99,20 +107,29 @@ class VisionController extends StateNotifier<VisionState> {
         orElse: () => cameras.first,
       );
       _lens = desc.lensDirection;
-      final controller = CameraController(
+      controller = CameraController(
         desc,
         ResolutionPreset.medium,
         enableAudio: false,
         imageFormatGroup:
             Platform.isAndroid ? ImageFormatGroup.nv21 : ImageFormatGroup.bgra8888,
       );
-      _camera = controller;
       await controller.initialize();
-      if (!mounted) {
+      // Bail out (and release) if we left the screen while initializing.
+      if (session != _session || !mounted) {
         await controller.dispose();
         return;
       }
       await controller.startImageStream(_process);
+      if (session != _session) {
+        try {
+          await controller.stopImageStream();
+        } catch (_) {}
+        await controller.dispose();
+        return;
+      }
+      // Only now does the controller become the live camera.
+      _camera = controller;
       state = state.copyWith(
         initializing: false,
         active: true,
@@ -121,10 +138,15 @@ class VisionController extends StateNotifier<VisionState> {
       );
     } catch (e, st) {
       AppLogger.e('Camera start failed', error: e, stackTrace: st, tag: 'Vision');
-      state = state.copyWith(
-        initializing: false,
-        error: 'Camera unavailable. Please grant camera permission.',
-      );
+      try {
+        await controller?.dispose();
+      } catch (_) {}
+      if (session == _session) {
+        state = state.copyWith(
+          initializing: false,
+          error: 'Camera unavailable. Please grant camera permission.',
+        );
+      }
     }
   }
 
@@ -175,6 +197,7 @@ class VisionController extends StateNotifier<VisionState> {
   }
 
   Future<void> stop() async {
+    _session++; // invalidate any in-flight start()
     final cam = _camera;
     _camera = null;
     if (mounted) {

--- a/lib/features/voice/providers/voice_provider.dart
+++ b/lib/features/voice/providers/voice_provider.dart
@@ -50,6 +50,8 @@ class VoiceController extends StateNotifier<VoiceState> {
 
   final Ref _ref;
   void Function(String)? _onFinal;
+  String _heard = ''; // latest recognized text this session
+  bool _delivered = true; // whether _heard was already sent (or discarded)
   Timer? _speakPulse;
   final math.Random _rng = math.Random();
 
@@ -65,9 +67,9 @@ class VoiceController extends StateNotifier<VoiceState> {
     );
     final available = await _stt.init(
       onStatus: (status) {
-        if (status == 'done' || status == 'notListening') _finishListening();
+        if (status == 'done' || status == 'notListening') _endSession();
       },
-      onError: (_) => _finishListening(),
+      onError: (_) => _endSession(),
     );
     state = state.copyWith(sttAvailable: available);
   }
@@ -85,14 +87,19 @@ class VoiceController extends StateNotifier<VoiceState> {
     if (!state.sttAvailable || state.isListening) return;
     await _tts.stop();
     _onFinal = onFinal;
+    _heard = '';
+    _delivered = false;
     state = state.copyWith(isListening: true, partialText: '');
     _avatar.setActivity(AvatarActivity.listening);
     await _stt.listen(
-      onPartial: (txt) => state = state.copyWith(partialText: txt),
+      onPartial: (txt) {
+        _heard = txt;
+        state = state.copyWith(partialText: txt);
+      },
       onFinal: (txt) {
-        final trimmed = txt.trim();
+        if (txt.trim().isNotEmpty) _heard = txt;
+        _deliverHeard();
         _finishListening();
-        if (trimmed.isNotEmpty) _onFinal?.call(trimmed);
       },
       onLevel: (level) =>
           _avatar.setAmplitude((level.abs() / 10).clamp(0.05, 1.0).toDouble()),
@@ -100,6 +107,8 @@ class VoiceController extends StateNotifier<VoiceState> {
   }
 
   Future<void> stopListening() async {
+    // Explicit stop (mute, or before speaking): discard any in-progress partial.
+    _delivered = true;
     await _stt.stop();
     _finishListening();
   }
@@ -108,6 +117,20 @@ class VoiceController extends StateNotifier<VoiceState> {
     if (!state.isListening) return;
     state = state.copyWith(isListening: false, partialText: '');
     _avatar.idle();
+  }
+
+  // If a listen session ends without a FINAL result (common on Android), still
+  // deliver the last recognized partial so the user's speech is never dropped.
+  void _endSession() {
+    _deliverHeard();
+    _finishListening();
+  }
+
+  void _deliverHeard() {
+    if (_delivered) return;
+    _delivered = true;
+    final text = _heard.trim();
+    if (text.isNotEmpty) _onFinal?.call(text);
   }
 
   // --- Speaking ---

--- a/lib/services/voice/stt_service.dart
+++ b/lib/services/voice/stt_service.dart
@@ -52,13 +52,14 @@ class SttService {
       onSoundLevelChange: onLevel,
       listenOptions: SpeechListenOptions(
         partialResults: true,
-        cancelOnError: true,
-        // Dictation mode keeps the recognizer open through natural pauses
-        // instead of ending on the first short phrase, so a sentence isn't
-        // chopped into separate sessions. Longer windows reduce restarts.
-        listenMode: ListenMode.dictation,
-        listenFor: const Duration(seconds: 60),
-        pauseFor: const Duration(seconds: 5),
+        cancelOnError: false,
+        // confirmation mode reliably emits a FINAL result when the speaker
+        // pauses (dictation mode often only streams partials and never
+        // finalizes, which left speech unsent). The VoiceController also
+        // flushes the last partial on session-end as a safety net.
+        listenMode: ListenMode.confirmation,
+        listenFor: const Duration(seconds: 30),
+        pauseFor: const Duration(seconds: 3),
         localeId: 'en_US',
       ),
     );

--- a/lib/services/voice/stt_service.dart
+++ b/lib/services/voice/stt_service.dart
@@ -53,9 +53,12 @@ class SttService {
       listenOptions: SpeechListenOptions(
         partialResults: true,
         cancelOnError: true,
-        listenMode: ListenMode.confirmation,
-        listenFor: const Duration(seconds: 30),
-        pauseFor: const Duration(seconds: 3),
+        // Dictation mode keeps the recognizer open through natural pauses
+        // instead of ending on the first short phrase, so a sentence isn't
+        // chopped into separate sessions. Longer windows reduce restarts.
+        listenMode: ListenMode.dictation,
+        listenFor: const Duration(seconds: 60),
+        pauseFor: const Duration(seconds: 5),
         localeId: 'en_US',
       ),
     );


### PR DESCRIPTION
Fixes #12

Addresses both problems reported in the issue.

## 1. Camera stays on when entering/leaving Live
The #9/#11 fix made `dispose()` always run, but a **race** remained: `start()` is async, so if you left the screen (or `switchCamera` ran) while the camera was still initializing, `stop()` would run first and the in-flight `start()` would then re-acquire the camera *after* it — leaking it, so the OS indicator stayed on.

**Fix (`vision_provider.dart`):** a session counter. `stop()` increments it to invalidate any in-flight `start()`; `start()` re-checks the session after every `await` and only assigns `_camera` once it confirms it's still current — otherwise it disposes the controller it built. The camera is now released on every exit.

## 2. Mic randomly opens/closes and resets mid-sentence
Two causes:
- **`ListenMode.confirmation`** made the Android recognizer stop after the first short phrase, chopping a sentence into separate sessions (the "reset as if a new session started").
- The 800ms hands-free supervisor restarted the recognizer with no throttle, and the UI was tied to the raw `isListening` flag, so it visibly flapped between sessions.

**Fixes:**
- `stt_service.dart`: switch to **`ListenMode.dictation`** and lengthen `listenFor` (60s) / `pauseFor` (5s) so the session stays open through natural pauses.
- `vision_screen.dart`: add a **1.5s restart cooldown** so the recognizer can't rapidly flap, and drive the caption + mic visuals from a steady "listening mode" (hands-free && not speaking && not thinking) instead of the raw `isListening` flag, so the UI no longer flickers. Hint now reads Listening / Thinking / Speaking.

## Commits (one per concern)
1. `fix(vision): make camera start/stop race-safe so it always releases`
2. `fix(voice): use dictation mode + longer listen window`
3. `fix(vision): throttle mic restarts + steady listening UI`

## Test plan
- [ ] Home → Live → camera indicator turns on.
- [ ] Exit (back) → camera indicator turns **off** within a moment; enter/exit repeatedly → no leak.
- [ ] Enter and immediately exit (before the preview is ready) → camera still releases (race).
- [ ] In Live, speak a full sentence with short pauses → it's captured as one utterance (no mid-sentence reset).
- [ ] The mic button / caption stay steady (no rapid open/close flicker) while hands-free.
- [ ] Mute toggle still stops listening; she still talks first and replies.

## Notes
- `flutter analyze` is clean (verified locally on Flutter 3.29.3).
- On Android the OS mic indicator may still blink briefly between utterances when idle — inherent to `speech_to_text` (no foreground service); the in-app UI is now steady and the mute toggle is available.
- Built on top of the merged #9/#11 camera fix.