### PR TITLE
feat(chat): saved conversations + chat history (#8)

### DIFF
--- a/lib/features/chat/data/models/chat_conversation.dart
+++ b/lib/features/chat/data/models/chat_conversation.dart
@@ -1,0 +1,125 @@
+import 'package:uuid/uuid.dart';
+
+import 'chat_message.dart';
+
+/// A single saved conversation thread with Vyra. The chat used to be one
+/// ever-growing rolling log; conversations let the user keep, revisit and
+/// manage distinct chats (issue #8). Persisted to Hive as a plain map (no
+/// codegen) so history survives restarts.
+class ChatConversation {
+  final String id;
+
+  /// Optional explicit title. When empty, [displayTitle] derives one from the
+  /// first user message.
+  final String title;
+  final List<ChatMessage> messages;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  ChatConversation({
+    String? id,
+    this.title = '',
+    this.messages = const [],
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  })  : id = id ?? const Uuid().v4(),
+        createdAt = createdAt ?? DateTime.now(),
+        updatedAt = updatedAt ?? DateTime.now();
+
+  /// A brand-new conversation seeded with Vyra's greeting.
+  factory ChatConversation.fresh(ChatMessage greeting) =>
+      ChatConversation(messages: [greeting]);
+
+  /// Folds the legacy single rolling history into one conversation so existing
+  /// users don't lose their chat when upgrading. [messages] must be non-empty.
+  factory ChatConversation.fromMessages(List<ChatMessage> messages) =>
+      ChatConversation(
+        messages: messages,
+        createdAt: messages.first.timestamp,
+        updatedAt: messages.last.timestamp,
+      );
+
+  bool get isEmpty => messages.isEmpty;
+  int get messageCount => messages.length;
+
+  /// A human-friendly title: the explicit title, else the first thing the user
+  /// said, else a sensible default.
+  String get displayTitle {
+    if (title.trim().isNotEmpty) return title.trim();
+    for (final m in messages) {
+      if (m.isUser && m.text.trim().isNotEmpty) {
+        return _truncate(m.text.trim(), 40);
+      }
+    }
+    return 'New chat';
+  }
+
+  /// A one-line preview of the latest message for the history list.
+  String get preview {
+    for (final m in messages.reversed) {
+      if (m.text.trim().isNotEmpty) {
+        final who = m.isUser ? 'You: ' : '';
+        return _truncate('$who${m.text.trim()}', 80);
+      }
+    }
+    return 'No messages yet';
+  }
+
+  ChatConversation addMessage(ChatMessage message) =>
+      copyWith(messages: [...messages, message]);
+
+  ChatConversation touch() => copyWith(updatedAt: DateTime.now());
+
+  ChatConversation copyWith({
+    String? title,
+    List<ChatMessage>? messages,
+    DateTime? updatedAt,
+  }) =>
+      ChatConversation(
+        id: id,
+        title: title ?? this.title,
+        messages: messages ?? this.messages,
+        createdAt: createdAt,
+        updatedAt: updatedAt ?? this.updatedAt,
+      );
+
+  /// Serializes the conversation, keeping only the most recent [maxMessages]
+  /// so a very long chat can't grow Hive without bound.
+  Map<String, dynamic> toMap({int maxMessages = 200}) {
+    final msgs = messages.length > maxMessages
+        ? messages.sublist(messages.length - maxMessages)
+        : messages;
+    return {
+      'id': id,
+      'title': title,
+      'createdAt': createdAt.millisecondsSinceEpoch,
+      'updatedAt': updatedAt.millisecondsSinceEpoch,
+      'messages': [for (final m in msgs) m.toMap()],
+    };
+  }
+
+  factory ChatConversation.fromMap(Map map) {
+    final msgs = <ChatMessage>[];
+    final raw = map['messages'];
+    if (raw is List) {
+      for (final e in raw) {
+        if (e is Map) msgs.add(ChatMessage.fromMap(e));
+      }
+    }
+    final now = DateTime.now().millisecondsSinceEpoch;
+    return ChatConversation(
+      id: map['id'] as String?,
+      title: (map['title'] as String?) ?? '',
+      messages: msgs,
+      createdAt: DateTime.fromMillisecondsSinceEpoch(
+        (map['createdAt'] as int?) ?? now,
+      ),
+      updatedAt: DateTime.fromMillisecondsSinceEpoch(
+        (map['updatedAt'] as int?) ?? now,
+      ),
+    );
+  }
+
+  static String _truncate(String s, int n) =>
+      s.length <= n ? s : '${s.substring(0, n).trimRight()}…';
+}

--- a/lib/features/chat/presentation/screens/chat_history_screen.dart
+++ b/lib/features/chat/presentation/screens/chat_history_screen.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/theme/app_text_styles.dart';
+import '../../data/models/chat_conversation.dart';
+import '../../providers/chat_provider.dart';
+
+/// Browse, reopen and manage past conversations with Vyra (issue #8).
+class ChatHistoryScreen extends ConsumerWidget {
+  const ChatHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final conversations = ref.watch(
+      chatControllerProvider.select((s) => s.conversations),
+    );
+    final activeId =
+        ref.watch(chatControllerProvider.select((s) => s.activeId));
+    final controller = ref.read(chatControllerProvider.notifier);
+
+    // Defensive: present most-recent first regardless of internal ordering.
+    final sorted = [...conversations]
+      ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Chat history'),
+        actions: [
+          IconButton(
+            tooltip: 'New chat',
+            icon: const Icon(Icons.add_comment_outlined),
+            onPressed: () {
+              controller.newConversation();
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      ),
+      body: Container(
+        decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+        child: SafeArea(
+          top: false,
+          child: sorted.isEmpty
+              ? const _EmptyHistory()
+              : ListView.separated(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 28),
+                  itemCount: sorted.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 10),
+                  itemBuilder: (context, i) {
+                    final convo = sorted[i];
+                    return _ConversationTile(
+                      conversation: convo,
+                      isActive: convo.id == activeId,
+                      onOpen: () {
+                        controller.openConversation(convo.id);
+                        Navigator.of(context).pop();
+                      },
+                      onDelete: () =>
+                          _confirmDelete(context, controller, convo),
+                    );
+                  },
+                ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _confirmDelete(
+    BuildContext context,
+    ChatController controller,
+    ChatConversation convo,
+  ) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        backgroundColor: AppColors.surface,
+        title: Text('Delete this chat?', style: AppTextStyles.title),
+        content: Text(
+          '“${convo.displayTitle}” will be removed from this device. This '
+          "can't be undone.",
+          style: AppTextStyles.bodyMuted,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text('Delete', style: TextStyle(color: AppColors.error)),
+          ),
+        ],
+      ),
+    );
+    if (ok == true) controller.deleteConversation(convo.id);
+  }
+}
+
+class _ConversationTile extends StatelessWidget {
+  const _ConversationTile({
+    required this.conversation,
+    required this.isActive,
+    required this.onOpen,
+    required this.onDelete,
+  });
+
+  final ChatConversation conversation;
+  final bool isActive;
+  final VoidCallback onOpen;
+  final VoidCallback onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      color: AppColors.surface,
+      borderRadius: BorderRadius.circular(18),
+      child: InkWell(
+        onTap: onOpen,
+        borderRadius: BorderRadius.circular(18),
+        child: Container(
+          padding: const EdgeInsets.fromLTRB(16, 14, 8, 14),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(18),
+            border: isActive
+                ? Border.all(color: AppColors.accent.withValues(alpha: 0.6))
+                : null,
+          ),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            conversation.displayTitle,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: AppTextStyles.title,
+                          ),
+                        ),
+                        if (isActive) ...[
+                          const SizedBox(width: 8),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 8, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: AppColors.accent.withValues(alpha: 0.18),
+                              borderRadius: BorderRadius.circular(20),
+                            ),
+                            child: Text('Current',
+                                style: AppTextStyles.caption
+                                    .copyWith(color: AppColors.accent)),
+                          ),
+                        ],
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      conversation.preview,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: AppTextStyles.bodyMuted,
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '${_relativeTime(conversation.updatedAt)} • '
+                      '${conversation.messageCount} message'
+                      '${conversation.messageCount == 1 ? '' : 's'}',
+                      style: AppTextStyles.caption,
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                tooltip: 'Delete',
+                icon: const Icon(Icons.delete_outline_rounded,
+                    color: AppColors.textMuted),
+                onPressed: onDelete,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  static String _relativeTime(DateTime t) {
+    final diff = DateTime.now().difference(t);
+    if (diff.inMinutes < 1) return 'Just now';
+    if (diff.inMinutes < 60) return '${diff.inMinutes}m ago';
+    if (diff.inHours < 24) return '${diff.inHours}h ago';
+    if (diff.inDays == 1) return 'Yesterday';
+    if (diff.inDays < 7) return '${diff.inDays}d ago';
+    return DateFormat.MMMd().format(t);
+  }
+}
+
+class _EmptyHistory extends StatelessWidget {
+  const _EmptyHistory();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.forum_outlined,
+                color: AppColors.textMuted, size: 44),
+            const SizedBox(height: 12),
+            Text('No conversations yet',
+                style: AppTextStyles.title, textAlign: TextAlign.center),
+            const SizedBox(height: 6),
+            Text(
+              'Your chats with Vyra will show up here so you can pick any of '
+              'them back up later.',
+              textAlign: TextAlign.center,
+              style: AppTextStyles.bodyMuted,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/chat/presentation/screens/chat_history_screen.dart
+++ b/lib/features/chat/presentation/screens/chat_history_screen.dart
@@ -39,7 +39,7 @@ class ChatHistoryScreen extends ConsumerWidget {
         ],
       ),
       body: Container(
-        decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+        decoration: BoxDecoration(gradient: AppColors.backgroundGradient),
         child: SafeArea(
           top: false,
           child: sorted.isEmpty
@@ -179,7 +179,7 @@ class _ConversationTile extends StatelessWidget {
               ),
               IconButton(
                 tooltip: 'Delete',
-                icon: const Icon(Icons.delete_outline_rounded,
+                icon: Icon(Icons.delete_outline_rounded,
                     color: AppColors.textMuted),
                 onPressed: onDelete,
               ),
@@ -212,7 +212,7 @@ class _EmptyHistory extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const Icon(Icons.forum_outlined,
+            Icon(Icons.forum_outlined,
                 color: AppColors.textMuted, size: 44),
             const SizedBox(height: 12),
             Text('No conversations yet',

--- a/lib/features/chat/presentation/screens/chat_screen.dart
+++ b/lib/features/chat/presentation/screens/chat_screen.dart
@@ -10,6 +10,7 @@ import '../../../avatar/providers/avatar_provider.dart';
 import '../../../voice/presentation/widgets/voice_wave.dart';
 import '../../../voice/providers/voice_provider.dart';
 import '../../providers/chat_provider.dart';
+import 'chat_history_screen.dart';
 import '../widgets/chat_input_bar.dart';
 import '../widgets/message_bubble.dart';
 import '../widgets/typing_indicator.dart';
@@ -43,29 +44,17 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
     });
   }
 
-  Future<void> _confirmClear() async {
-    final ok = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        backgroundColor: AppColors.surface,
-        title: Text('Clear conversation?', style: AppTextStyles.title),
-        content: Text(
-          'This will erase your chat history with Vyra on this device.',
-          style: AppTextStyles.bodyMuted,
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: Text('Clear', style: TextStyle(color: AppColors.error)),
-          ),
-        ],
-      ),
+  void _openHistory() {
+    Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const ChatHistoryScreen()),
     );
-    if (ok == true) ref.read(chatControllerProvider.notifier).clear();
+  }
+
+  void _newChat() {
+    // The current conversation is already saved, so starting a new one is
+    // non-destructive — no scary confirm needed.
+    ref.read(chatControllerProvider.notifier).newConversation();
+    context.showSnack('Started a new chat — the old one is in History');
   }
 
   @override
@@ -88,7 +77,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
         child: SafeArea(
           child: Column(
             children: [
-              _ChatHeader(onClear: _confirmClear),
+              _ChatHeader(onHistory: _openHistory, onNew: _newChat),
               Expanded(
                 child: ListView.builder(
                   controller: _scroll,
@@ -163,9 +152,10 @@ class _ListeningBanner extends StatelessWidget {
 }
 
 class _ChatHeader extends ConsumerWidget {
-  const _ChatHeader({required this.onClear});
+  const _ChatHeader({required this.onHistory, required this.onNew});
 
-  final VoidCallback onClear;
+  final VoidCallback onHistory;
+  final VoidCallback onNew;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -208,9 +198,14 @@ class _ChatHeader extends ConsumerWidget {
             ),
           ),
           IconButton(
-            tooltip: 'Clear chat',
-            icon: const Icon(Icons.delete_sweep_outlined),
-            onPressed: onClear,
+            tooltip: 'Chat history',
+            icon: const Icon(Icons.history_rounded),
+            onPressed: onHistory,
+          ),
+          IconButton(
+            tooltip: 'New chat',
+            icon: const Icon(Icons.add_comment_outlined),
+            onPressed: onNew,
           ),
         ],
       ),

--- a/lib/features/chat/providers/chat_provider.dart
+++ b/lib/features/chat/providers/chat_provider.dart
@@ -8,6 +8,7 @@ import '../../../services/service_providers.dart';
 import '../../avatar/models/avatar_emotion.dart';
 import '../../avatar/providers/avatar_provider.dart';
 import '../../voice/providers/voice_provider.dart';
+import '../data/models/chat_conversation.dart';
 import '../data/models/chat_message.dart';
 
 final geminiServiceProvider =
@@ -15,70 +16,151 @@ final geminiServiceProvider =
 
 @immutable
 class ChatState {
-  final List<ChatMessage> messages;
+  /// All saved conversations, most-recently-updated first.
+  final List<ChatConversation> conversations;
+
+  /// The conversation currently shown in the chat screen.
+  final String? activeId;
   final bool isResponding;
 
-  const ChatState({this.messages = const [], this.isResponding = false});
+  const ChatState({
+    this.conversations = const [],
+    this.activeId,
+    this.isResponding = false,
+  });
 
-  ChatState copyWith({List<ChatMessage>? messages, bool? isResponding}) =>
+  ChatConversation? get active {
+    for (final c in conversations) {
+      if (c.id == activeId) return c;
+    }
+    return null;
+  }
+
+  /// The active conversation's messages — the existing surface the chat UI,
+  /// vision screen and home hub all read.
+  List<ChatMessage> get messages => active?.messages ?? const [];
+
+  ChatState copyWith({
+    List<ChatConversation>? conversations,
+    String? activeId,
+    bool? isResponding,
+  }) =>
       ChatState(
-        messages: messages ?? this.messages,
+        conversations: conversations ?? this.conversations,
+        activeId: activeId ?? this.activeId,
         isResponding: isResponding ?? this.isResponding,
       );
 }
 
-/// Orchestrates the conversation: persists history to Hive, talks to Gemini,
-/// and pushes emotion/activity changes to the avatar so Vyra's face reacts.
+/// Orchestrates the conversation: persists a list of saved conversations to
+/// Hive, talks to Gemini for the active one, and pushes emotion/activity
+/// changes to the avatar so Vyra's face reacts.
 class ChatController extends StateNotifier<ChatState> {
   ChatController(this._ref) : super(const ChatState()) {
     _restore();
   }
 
   final Ref _ref;
-  static const String _historyKey = 'history';
-  static const int _maxStored = 200;
+
+  static const String _convosKey = 'conversations';
+  static const String _activeKey = 'active_id';
+  static const String _legacyKey = 'history'; // old single rolling log
+  static const int _maxConversations = 40;
+  static const int _maxMessagesStored = 200;
 
   GeminiService get _gemini => _ref.read(geminiServiceProvider);
   AvatarController get _avatar => _ref.read(avatarControllerProvider.notifier);
 
   void _restore() {
     final box = _ref.read(storageServiceProvider).chatBox;
-    final raw = box.get(_historyKey);
-    if (raw is List && raw.isNotEmpty) {
-      final messages = raw
-          .whereType<Map>()
-          .map(ChatMessage.fromMap)
-          .toList(growable: true);
-      state = state.copyWith(messages: messages);
-      _gemini.seedHistory([
-        for (final m in messages) (isUser: m.isUser, text: m.text),
-      ]);
-    } else {
-      _greet();
+
+    final convos = <ChatConversation>[];
+    final rawConvos = box.get(_convosKey);
+    if (rawConvos is List) {
+      for (final e in rawConvos) {
+        if (e is Map) convos.add(ChatConversation.fromMap(e));
+      }
     }
+
+    // One-time migration: fold the legacy rolling history into a conversation
+    // so upgrading users keep their chat.
+    if (convos.isEmpty) {
+      final legacy = box.get(_legacyKey);
+      if (legacy is List && legacy.isNotEmpty) {
+        final msgs =
+            legacy.whereType<Map>().map(ChatMessage.fromMap).toList();
+        if (msgs.isNotEmpty) convos.add(ChatConversation.fromMessages(msgs));
+      }
+    }
+    box.delete(_legacyKey); // legacy folded in (or absent) — safe to drop
+
+    if (convos.isEmpty) {
+      _startFresh(persist: true);
+      return;
+    }
+
+    convos.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+    final storedActive = box.get(_activeKey) as String?;
+    final activeId = convos.any((c) => c.id == storedActive)
+        ? storedActive!
+        : convos.first.id;
+    state = ChatState(conversations: convos, activeId: activeId);
+    _seedGeminiFromActive();
   }
 
-  void _greet() {
+  ChatMessage _greetingMessage() {
     final name = _ref.read(storageServiceProvider).userName;
     final hi = name.isEmpty ? 'Hey there' : 'Hey $name';
-    final greeting = ChatMessage.vyra(
+    return ChatMessage.vyra(
       "$hi! I'm Vyra. Ask me anything, or just tell me how your day's going. 💜",
       emotion: AvatarEmotion.happy,
     );
-    state = state.copyWith(messages: [greeting]);
+  }
+
+  /// Creates a brand-new active conversation with a greeting.
+  void _startFresh({bool persist = false}) {
+    final convo = ChatConversation.fresh(_greetingMessage());
+    state = state.copyWith(
+      conversations: [convo, ...state.conversations],
+      activeId: convo.id,
+    );
+    _gemini.resetSession();
     _avatar.react(AvatarEmotion.happy);
-    _persist();
+    if (persist) _persist();
+  }
+
+  void _seedGeminiFromActive() {
+    _gemini.seedHistory([
+      for (final m in state.messages) (isUser: m.isUser, text: m.text),
+    ]);
+  }
+
+  /// Applies a transform to the active conversation, then moves it to the front
+  /// of the list (most-recent-first ordering for the history screen).
+  void _updateActive(ChatConversation Function(ChatConversation) transform) {
+    final id = state.activeId;
+    if (id == null) return;
+    final rest = <ChatConversation>[];
+    ChatConversation? changed;
+    for (final c in state.conversations) {
+      if (c.id == id) {
+        changed = transform(c).touch();
+      } else {
+        rest.add(c);
+      }
+    }
+    if (changed == null) return;
+    state = state.copyWith(conversations: [changed, ...rest]);
   }
 
   Future<void> send(String text) async {
     final trimmed = text.trim();
     if (trimmed.isEmpty || state.isResponding) return;
+    if (state.active == null) _startFresh();
 
     final userMsg = ChatMessage.user(trimmed);
-    state = state.copyWith(
-      messages: [...state.messages, userMsg],
-      isResponding: true,
-    );
+    _updateActive((c) => c.addMessage(userMsg));
+    state = state.copyWith(isResponding: true);
     _avatar.setActivity(AvatarActivity.thinking);
     _persist();
 
@@ -90,10 +172,8 @@ class ChatController extends StateNotifier<ChatState> {
       isError: reply.isError,
     );
 
-    state = state.copyWith(
-      messages: [...state.messages, vyraMsg],
-      isResponding: false,
-    );
+    _updateActive((c) => c.addMessage(vyraMsg));
+    state = state.copyWith(isResponding: false);
     // React with the emotion; if TTS is on, the voice layer then flips the
     // avatar to "speaking" while it reads the reply aloud.
     _avatar.react(emotion, activity: AvatarActivity.idle);
@@ -103,21 +183,63 @@ class ChatController extends StateNotifier<ChatState> {
     }
   }
 
+  /// Starts a new conversation; the current one stays saved in history.
+  void newConversation() => _startFresh(persist: true);
+
+  /// Switches the active conversation and re-seeds Gemini with its context.
+  void openConversation(String id) {
+    if (id == state.activeId) return;
+    if (!state.conversations.any((c) => c.id == id)) return;
+    state = state.copyWith(activeId: id);
+    _ref.read(storageServiceProvider).chatBox.put(_activeKey, id);
+    _gemini.resetSession();
+    _seedGeminiFromActive();
+    // Reflect that conversation's last mood on the avatar.
+    final msgs = state.messages;
+    final lastEmotion = msgs.isEmpty ? AvatarEmotion.neutral : msgs.last.emotion;
+    _avatar.react(lastEmotion, activity: AvatarActivity.idle);
+  }
+
+  /// Deletes a conversation. If it was active, falls back to the most recent
+  /// remaining one (or a fresh chat when none remain).
+  void deleteConversation(String id) {
+    final remaining = state.conversations.where((c) => c.id != id).toList();
+    final wasActive = state.activeId == id;
+    if (remaining.isEmpty) {
+      state = const ChatState();
+      _startFresh(persist: true);
+      return;
+    }
+    state = state.copyWith(
+      conversations: remaining,
+      activeId: wasActive ? remaining.first.id : state.activeId,
+    );
+    _persist();
+    if (wasActive) {
+      _gemini.resetSession();
+      _seedGeminiFromActive();
+    }
+  }
+
+  /// "Clear chat history" — wipes every saved conversation and starts over.
   void clear() {
+    final box = _ref.read(storageServiceProvider).chatBox;
+    box.delete(_convosKey);
+    box.delete(_activeKey);
+    box.delete(_legacyKey);
     state = const ChatState();
     _gemini.resetSession();
     _avatar.react(AvatarEmotion.neutral, activity: AvatarActivity.idle);
-    _ref.read(storageServiceProvider).chatBox.delete(_historyKey);
-    _greet();
+    _startFresh(persist: true);
   }
 
   void _persist() {
     final box = _ref.read(storageServiceProvider).chatBox;
-    final toStore = state.messages
-        .take(_maxStored)
-        .map((m) => m.toMap())
-        .toList(growable: false);
-    box.put(_historyKey, toStore);
+    final convos = state.conversations.take(_maxConversations).toList();
+    box.put(_convosKey, [
+      for (final c in convos) c.toMap(maxMessages: _maxMessagesStored),
+    ]);
+    if (state.activeId != null) box.put(_activeKey, state.activeId);
   }
 }
 


### PR DESCRIPTION
## Summary
Closes #8 — adds the ability to keep and revisit past conversations instead of one single rolling chat that gets wiped on "clear".

## What changed
**Data**
- New `ChatConversation` model (id, title, messages, created/updated timestamps) with map (de)serialization, a `displayTitle` derived from the first user message, and a one-line `preview`.

**Controller** (`ChatController`)
- Now manages a **list** of conversations plus an **active** one. `state.messages` still returns the active thread, so every existing caller (chat screen, vision screen, home hub) is unchanged.
- New operations: `newConversation()`, `openConversation(id)`, `deleteConversation(id)`. `send()` and `clear()` are preserved.
- **Migration**: on first launch the legacy single `history` log is folded into one conversation, so existing users keep their chat.
- Bounded storage: 200 messages per conversation, 40 conversations max.

**UI**
- New `ChatHistoryScreen`: lists conversations (title, last-message preview, relative time, message count), highlights the current one, opens one on tap, supports per-chat delete (with confirm) and a New chat action.
- Chat header swaps the single "clear" trash icon for **History** + **New chat**. Starting a new chat is now non-destructive (the old thread is saved). The destructive clear-all still lives in Settings.

## Test plan
- [ ] Existing users: prior chat appears as one conversation in History after update.
- [ ] Send messages → conversation moves to top with updated preview/time.
- [ ] New chat → fresh greeting; previous chat still in History.
- [ ] Open an old conversation → messages restore and Gemini context is re-seeded.
- [ ] Delete a conversation (active and non-active) → falls back correctly; deleting the last creates a fresh chat.
- [ ] Settings → Clear chat history wipes everything and starts fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)