### PR TITLE
feat(theme): make Light mode actually work app-wide (#7)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'core/config/flavor_config.dart';
 import 'core/providers/settings_provider.dart';
+import 'core/theme/app_colors.dart';
 import 'core/theme/app_theme.dart';
 import 'services/service_providers.dart';
 import 'shared/widgets/flavor_banner.dart';
@@ -18,6 +19,19 @@ class VyraApp extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final themeMode = ref.watch(settingsProvider.select((s) => s.themeMode));
     final onboardingDone = ref.read(storageServiceProvider).onboardingDone;
+
+    // Resolve the brightness MaterialApp will actually display and publish it to
+    // AppColors *before* the themes are built below, so every brightness-aware
+    // token (surfaces, gradient, text) matches the visible theme. Reading the
+    // platform brightness here also rebuilds the app when the OS flips
+    // light/dark while themeMode is "system".
+    final platformBrightness =
+        MediaQuery.maybeOf(context)?.platformBrightness ?? Brightness.dark;
+    AppColors.brightness = switch (themeMode) {
+      ThemeMode.light => Brightness.light,
+      ThemeMode.dark => Brightness.dark,
+      ThemeMode.system => platformBrightness,
+    };
 
     return MaterialApp(
       title: FlavorConfig.appTitle,

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -2,13 +2,30 @@ import 'package:flutter/material.dart';
 
 /// Central color palette for Vyra.
 ///
-/// Vyra's visual identity is a "calm intelligence in deep space" — a dark,
-/// violet-leaning canvas that lets the animated avatar glow with gradients of
-/// violet → cyan. Emotion accents shift the glow to communicate mood.
+/// Vyra's visual identity is a "calm intelligence in deep space" — a violet-
+/// leaning canvas that lets the animated avatar glow with gradients of
+/// violet → cyan. The brand hues (violet/cyan/pink) are shared across themes;
+/// the **surfaces and text** flip with the active theme.
+///
+/// Light mode used to do almost nothing because every screen painted the dark
+/// surface/gradient/text tokens directly (issue #7). To fix that without
+/// rewriting ~100 call sites, the surface + text tokens below are now
+/// brightness-aware getters that resolve against [brightness], which the root
+/// widget sets to the live theme brightness on every build. `AppTextStyles`
+/// reads its colors from these getters too, so typography adapts automatically.
+///
+/// `AppTheme` builds each [ThemeData] from the explicit per-brightness
+/// constants (the `*Dark` / light-named ones) so theme construction never
+/// depends on the global, only the screen-facing getters do.
 class AppColors {
   AppColors._();
 
-  // --- Brand ---
+  /// The active brightness, set by the app root (see `VyraApp.build`) before any
+  /// screen builds. Defaults to dark — Vyra's signature look.
+  static Brightness brightness = Brightness.dark;
+  static bool get _isLight => brightness == Brightness.light;
+
+  // --- Brand (shared across themes) ---
   static const Color primary = Color(0xFF7C5CFF); // violet
   static const Color primaryDeep = Color(0xFF5B3FD9);
   static const Color primarySoft = Color(0xFFA48BFF);
@@ -16,30 +33,46 @@ class AppColors {
   static const Color accentDeep = Color(0xFF0EA5E9);
   static const Color accentPink = Color(0xFFFF5CA8);
 
-  // --- Backgrounds (dark, the default for Vyra) ---
+  // --- Raw dark surfaces ---
   static const Color bgDark = Color(0xFF0D0B1A);
   static const Color bgDarkAlt = Color(0xFF14102A);
-  static const Color surface = Color(0xFF1B1638);
-  static const Color surfaceAlt = Color(0xFF241D4A);
-  static const Color surfaceGlass = Color(0x33241D4A);
+  static const Color surfaceDark = Color(0xFF1B1638);
+  static const Color surfaceDarkAlt = Color(0xFF241D4A);
+  static const Color surfaceDarkGlass = Color(0x33241D4A);
 
-  // --- Backgrounds (light) ---
+  // --- Raw light surfaces ---
   static const Color bgLight = Color(0xFFF6F4FF);
+  static const Color bgLightAlt = Color(0xFFEDE9FF);
   static const Color surfaceLight = Color(0xFFFFFFFF);
   static const Color surfaceLightAlt = Color(0xFFEDE9FF);
+  static const Color surfaceLightGlass = Color(0x80FFFFFF);
 
-  // --- Text ---
-  static const Color textPrimary = Color(0xFFF4F2FF);
-  static const Color textSecondary = Color(0xFFB6AEDC);
-  static const Color textMuted = Color(0xFF6F6790);
+  // --- Raw text colors ---
+  static const Color textDarkPrimary = Color(0xFFF4F2FF);
+  static const Color textDarkSecondary = Color(0xFFB6AEDC);
+  static const Color textDarkMuted = Color(0xFF6F6790);
   static const Color textOnLight = Color(0xFF1B1638);
+  static const Color textLightSecondary = Color(0xFF5B5478);
+  static const Color textLightMuted = Color(0xFF8B84A6);
 
-  // --- Semantic ---
+  // --- Surfaces (brightness-aware, used by screens) ---
+  static Color get surface => _isLight ? surfaceLight : surfaceDark;
+  static Color get surfaceAlt => _isLight ? surfaceLightAlt : surfaceDarkAlt;
+  static Color get surfaceGlass =>
+      _isLight ? surfaceLightGlass : surfaceDarkGlass;
+
+  // --- Text (brightness-aware, used by screens + AppTextStyles) ---
+  static Color get textPrimary => _isLight ? textOnLight : textDarkPrimary;
+  static Color get textSecondary =>
+      _isLight ? textLightSecondary : textDarkSecondary;
+  static Color get textMuted => _isLight ? textLightMuted : textDarkMuted;
+
+  // --- Semantic (shared) ---
   static const Color success = Color(0xFF34D399);
   static const Color warning = Color(0xFFFBBF24);
   static const Color error = Color(0xFFFB7185);
 
-  // --- Gradients ---
+  // --- Gradients (shared brand) ---
   static const LinearGradient brandGradient = LinearGradient(
     colors: [primary, accent],
     begin: Alignment.topLeft,
@@ -57,9 +90,19 @@ class AppColors {
     radius: 0.85,
   );
 
-  static const LinearGradient backgroundGradient = LinearGradient(
+  static const LinearGradient backgroundGradientDark = LinearGradient(
     colors: [bgDark, bgDarkAlt],
     begin: Alignment.topCenter,
     end: Alignment.bottomCenter,
   );
+
+  static const LinearGradient backgroundGradientLight = LinearGradient(
+    colors: [bgLight, bgLightAlt],
+    begin: Alignment.topCenter,
+    end: Alignment.bottomCenter,
+  );
+
+  /// The full-screen background gradient for the current theme.
+  static LinearGradient get backgroundGradient =>
+      _isLight ? backgroundGradientLight : backgroundGradientDark;
 }

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -25,6 +25,17 @@ class AppColors {
   static Brightness brightness = Brightness.dark;
   static bool get _isLight => brightness == Brightness.light;
 
+  /// Syncs the active brightness from the inherited [Theme] and returns it.
+  ///
+  /// Call at the very top of a widget's `build()`: it both registers a
+  /// dependency on the Theme (so the widget rebuilds when the user flips
+  /// light/dark mid-session) and refreshes the brightness-aware tokens for the
+  /// reads that follow. Without it, screens that don't otherwise consume
+  /// `Theme.of(context)` keep painting the previous theme until the next app
+  /// launch (issue #7).
+  static Brightness sync(BuildContext context) =>
+      brightness = Theme.of(context).brightness;
+
   // --- Brand (shared across themes) ---
   static const Color primary = Color(0xFF7C5CFF); // violet
   static const Color primaryDeep = Color(0xFF5B3FD9);

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -4,42 +4,90 @@ import 'app_colors.dart';
 import 'app_text_styles.dart';
 
 /// Builds Vyra's [ThemeData]. The app is dark-first (the avatar is designed to
-/// glow against a deep violet canvas) but a light theme is provided too.
+/// glow against a deep violet canvas) but ships a fully-realized light theme
+/// too. Both are built from explicit per-brightness constants so theme
+/// construction never depends on the global `AppColors.brightness` — only the
+/// screen-facing tokens do (issue #7).
 class AppTheme {
   AppTheme._();
 
   static ThemeData get dark {
-    final base = ThemeData.dark(useMaterial3: true);
-    final scheme = const ColorScheme.dark(
+    final scheme = ColorScheme.dark(
       primary: AppColors.primary,
       secondary: AppColors.accent,
-      surface: AppColors.surface,
+      surface: AppColors.surfaceDark,
       error: AppColors.error,
       onPrimary: Colors.white,
-      onSecondary: Color(0xFF04212B),
-      onSurface: AppColors.textPrimary,
+      onSecondary: const Color(0xFF04212B),
+      onSurface: AppColors.textDarkPrimary,
     );
+    return _build(
+      base: ThemeData.dark(useMaterial3: true),
+      scheme: scheme,
+      scaffoldBg: AppColors.bgDark,
+      surface: AppColors.surfaceDark,
+      inputFill: AppColors.surfaceDarkAlt,
+      textColor: AppColors.textDarkPrimary,
+      mutedColor: AppColors.textDarkSecondary,
+      elevated: false,
+    );
+  }
 
+  static ThemeData get light {
+    final scheme = ColorScheme.light(
+      primary: AppColors.primary,
+      secondary: AppColors.accentDeep,
+      surface: AppColors.surfaceLight,
+      error: AppColors.error,
+      onPrimary: Colors.white,
+      onSecondary: Colors.white,
+      onSurface: AppColors.textOnLight,
+    );
+    return _build(
+      base: ThemeData.light(useMaterial3: true),
+      scheme: scheme,
+      scaffoldBg: AppColors.bgLight,
+      surface: AppColors.surfaceLight,
+      inputFill: AppColors.surfaceLightAlt,
+      textColor: AppColors.textOnLight,
+      mutedColor: AppColors.textLightSecondary,
+      // Light surfaces need a touch of elevation to separate from the canvas;
+      // the dark theme relies on color contrast instead.
+      elevated: true,
+    );
+  }
+
+  static ThemeData _build({
+    required ThemeData base,
+    required ColorScheme scheme,
+    required Color scaffoldBg,
+    required Color surface,
+    required Color inputFill,
+    required Color textColor,
+    required Color mutedColor,
+    required bool elevated,
+  }) {
     return base.copyWith(
       colorScheme: scheme,
-      scaffoldBackgroundColor: AppColors.bgDark,
-      canvasColor: AppColors.bgDark,
-      textTheme: _textTheme(base.textTheme, AppColors.textPrimary),
+      scaffoldBackgroundColor: scaffoldBg,
+      canvasColor: scaffoldBg,
+      textTheme: _textTheme(base.textTheme, textColor, mutedColor),
       appBarTheme: AppBarTheme(
         backgroundColor: Colors.transparent,
         elevation: 0,
         centerTitle: false,
-        titleTextStyle: AppTextStyles.heading,
-        iconTheme: const IconThemeData(color: AppColors.textPrimary),
+        titleTextStyle: AppTextStyles.heading.copyWith(color: textColor),
+        iconTheme: IconThemeData(color: textColor),
       ),
       cardTheme: CardThemeData(
-        color: AppColors.surface,
-        elevation: 0,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(20),
-        ),
+        color: surface,
+        elevation: elevated ? 1.5 : 0,
+        shadowColor:
+            elevated ? AppColors.primary.withValues(alpha: 0.14) : Colors.transparent,
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       ),
-      inputDecorationTheme: _inputTheme(AppColors.surfaceAlt),
+      inputDecorationTheme: _inputTheme(inputFill),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
           backgroundColor: AppColors.primary,
@@ -51,44 +99,52 @@ class AppTheme {
           ),
         ),
       ),
-      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
-        backgroundColor: AppColors.surface,
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(foregroundColor: AppColors.primary),
+      ),
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        backgroundColor: surface,
         selectedItemColor: AppColors.accent,
         unselectedItemColor: AppColors.textMuted,
         type: BottomNavigationBarType.fixed,
       ),
-      dividerColor: AppColors.surfaceAlt,
-      iconTheme: const IconThemeData(color: AppColors.textSecondary),
-    );
-  }
-
-  static ThemeData get light {
-    final base = ThemeData.light(useMaterial3: true);
-    final scheme = const ColorScheme.light(
-      primary: AppColors.primary,
-      secondary: AppColors.accentDeep,
-      surface: AppColors.surfaceLight,
-      error: AppColors.error,
-      onPrimary: Colors.white,
-      onSurface: AppColors.textOnLight,
-    );
-
-    return base.copyWith(
-      colorScheme: scheme,
-      scaffoldBackgroundColor: AppColors.bgLight,
-      textTheme: _textTheme(base.textTheme, AppColors.textOnLight),
-      appBarTheme: AppBarTheme(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        centerTitle: false,
-        titleTextStyle: AppTextStyles.heading.copyWith(color: AppColors.textOnLight),
-        iconTheme: const IconThemeData(color: AppColors.textOnLight),
+      navigationBarTheme: NavigationBarThemeData(
+        backgroundColor: surface,
+        indicatorColor: AppColors.primary.withValues(alpha: 0.20),
+        surfaceTintColor: Colors.transparent,
+        elevation: elevated ? 2 : 0,
       ),
-      inputDecorationTheme: _inputTheme(AppColors.surfaceLightAlt),
+      dialogTheme: DialogThemeData(
+        backgroundColor: surface,
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(22)),
+      ),
+      bottomSheetTheme: BottomSheetThemeData(
+        backgroundColor: surface,
+        surfaceTintColor: Colors.transparent,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+        backgroundColor: scheme.inverseSurface,
+        contentTextStyle:
+            AppTextStyles.body.copyWith(color: scheme.onInverseSurface),
+      ),
+      switchTheme: SwitchThemeData(
+        thumbColor: WidgetStateProperty.resolveWith((states) =>
+            states.contains(WidgetState.selected)
+                ? AppColors.accent
+                : null),
+        trackColor: WidgetStateProperty.resolveWith((states) =>
+            states.contains(WidgetState.selected)
+                ? AppColors.accent.withValues(alpha: 0.4)
+                : null),
+      ),
+      dividerColor: scheme.outlineVariant,
+      iconTheme: IconThemeData(color: mutedColor),
     );
   }
 
-  static TextTheme _textTheme(TextTheme base, Color color) {
+  static TextTheme _textTheme(TextTheme base, Color color, Color muted) {
     return base.copyWith(
       displaySmall: AppTextStyles.display.copyWith(color: color),
       headlineMedium: AppTextStyles.headingLarge.copyWith(color: color),
@@ -96,8 +152,8 @@ class AppTheme {
       titleMedium: AppTextStyles.title.copyWith(color: color),
       bodyLarge: AppTextStyles.body.copyWith(color: color),
       bodyMedium: AppTextStyles.body.copyWith(color: color),
-      labelLarge: AppTextStyles.label,
-      bodySmall: AppTextStyles.caption,
+      labelLarge: AppTextStyles.label.copyWith(color: muted),
+      bodySmall: AppTextStyles.caption.copyWith(color: muted),
     );
   }
 

--- a/lib/features/assistant/presentation/screens/assistant_screen.dart
+++ b/lib/features/assistant/presentation/screens/assistant_screen.dart
@@ -21,7 +21,7 @@ class AssistantScreen extends ConsumerWidget {
 
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+        decoration: BoxDecoration(gradient: AppColors.backgroundGradient),
         child: SafeArea(
           child: ListView(
             padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
@@ -114,7 +114,7 @@ class _EmptyReminders extends StatelessWidget {
       ),
       child: Column(
         children: [
-          const Icon(Icons.notifications_none_rounded,
+          Icon(Icons.notifications_none_rounded,
               color: AppColors.textMuted, size: 36),
           const SizedBox(height: 8),
           Text('No reminders yet',
@@ -227,7 +227,7 @@ class _AddReminderSheetState extends State<_AddReminderSheet> {
                   const Icon(Icons.schedule_rounded, color: AppColors.primarySoft),
                   const SizedBox(width: 12),
                   Expanded(child: Text(dateLabel, style: AppTextStyles.body)),
-                  const Icon(Icons.edit_calendar_rounded,
+                  Icon(Icons.edit_calendar_rounded,
                       color: AppColors.textMuted, size: 20),
                 ],
               ),

--- a/lib/features/assistant/presentation/screens/assistant_screen.dart
+++ b/lib/features/assistant/presentation/screens/assistant_screen.dart
@@ -15,6 +15,7 @@ class AssistantScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    AppColors.sync(context);
     final weather = ref.watch(weatherProvider);
     final reminders = ref.watch(remindersProvider);
     final fun = ref.watch(funContentProvider);

--- a/lib/features/chat/presentation/screens/chat_screen.dart
+++ b/lib/features/chat/presentation/screens/chat_screen.dart
@@ -84,7 +84,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+        decoration: BoxDecoration(gradient: AppColors.backgroundGradient),
         child: SafeArea(
           child: Column(
             children: [

--- a/lib/features/chat/presentation/screens/chat_screen.dart
+++ b/lib/features/chat/presentation/screens/chat_screen.dart
@@ -70,6 +70,7 @@ class _ChatScreenState extends ConsumerState<ChatScreen> {
 
   @override
   Widget build(BuildContext context) {
+    AppColors.sync(context);
     ref.listen(
       chatControllerProvider.select((s) => s.messages.length),
       (_, __) => _scrollToBottom(),

--- a/lib/features/home/presentation/screens/home_hub_screen.dart
+++ b/lib/features/home/presentation/screens/home_hub_screen.dart
@@ -36,7 +36,7 @@ class HomeHubScreen extends ConsumerWidget {
 
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+        decoration: BoxDecoration(gradient: AppColors.backgroundGradient),
         child: SafeArea(
           child: SingleChildScrollView(
             padding: const EdgeInsets.fromLTRB(20, 12, 20, 28),

--- a/lib/features/home/presentation/screens/home_hub_screen.dart
+++ b/lib/features/home/presentation/screens/home_hub_screen.dart
@@ -31,6 +31,7 @@ class HomeHubScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    AppColors.sync(context);
     final name = ref.watch(settingsProvider.select((s) => s.userName));
     final greeting = name.isEmpty ? _greeting() : '${_greeting()}, $name';
 

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -21,6 +21,7 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    AppColors.sync(context);
     final pages = [
       HomeHubScreen(onSelectTab: _select),
       const ChatScreen(),

--- a/lib/features/onboarding/presentation/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen.dart
@@ -84,7 +84,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     final isLast = _index == _pages.length - 1;
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+        decoration: BoxDecoration(gradient: AppColors.backgroundGradient),
         child: SafeArea(
           child: Column(
             children: [

--- a/lib/features/onboarding/presentation/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/presentation/screens/onboarding_screen.dart
@@ -81,6 +81,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   @override
   Widget build(BuildContext context) {
+    AppColors.sync(context);
     final isLast = _index == _pages.length - 1;
     return Scaffold(
       body: Container(

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -18,7 +18,7 @@ class SettingsScreen extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Settings')),
       body: Container(
-        decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+        decoration: BoxDecoration(gradient: AppColors.backgroundGradient),
         child: ListView(
           padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
           children: [

--- a/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/lib/features/settings/presentation/screens/settings_screen.dart
@@ -12,6 +12,7 @@ class SettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    AppColors.sync(context);
     final settings = ref.watch(settingsProvider);
     final notifier = ref.read(settingsProvider.notifier);
 

--- a/lib/features/vision/presentation/screens/vision_screen.dart
+++ b/lib/features/vision/presentation/screens/vision_screen.dart
@@ -201,6 +201,7 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
 
   @override
   Widget build(BuildContext context) {
+    AppColors.sync(context);
     ref.listen<VisionState>(visionControllerProvider, _onPresenceChange);
     ref.listen<VoiceState>(voiceControllerProvider, _onVoiceChange);
     ref.listen(chatControllerProvider.select((s) => s.messages.length), (_, __) {

--- a/lib/features/vision/presentation/screens/vision_screen.dart
+++ b/lib/features/vision/presentation/screens/vision_screen.dart
@@ -248,7 +248,7 @@ class _VisionScreenState extends ConsumerState<VisionScreen>
 
     return Scaffold(
       body: Container(
-        decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+        decoration: BoxDecoration(gradient: AppColors.backgroundGradient),
         child: SafeArea(
           child: Column(
             children: [

--- a/lib/shared/widgets/gradient_background.dart
+++ b/lib/shared/widgets/gradient_background.dart
@@ -13,7 +13,7 @@ class GradientBackground extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: const BoxDecoration(gradient: AppColors.backgroundGradient),
+      decoration: BoxDecoration(gradient: AppColors.backgroundGradient),
       child: safeArea ? SafeArea(child: child) : child,
     );
   }


### PR DESCRIPTION
## Summary
Closes #7 — Light mode was selectable in Settings but did almost nothing.

## Root cause
`MaterialApp` was correctly wired with `theme` / `darkTheme` / `themeMode`, but every screen painted the **dark** design tokens directly — `AppColors.backgroundGradient`, `AppColors.surface`, and `AppTextStyles.*` (which baked in light-on-dark text colors). So choosing *Light* kept the canvas dark and the text unreadable.

## Approach (hand-built theming — no new packages)
Rather than rewrite ~100 call sites, the **design tokens themselves are now brightness-aware**:

- **`AppColors`**: `surface`, `surfaceAlt`, `surfaceGlass`, `textPrimary/Secondary/Muted` and `backgroundGradient` became getters that resolve against `AppColors.brightness`. `AppTextStyles` reads its colors from these getters, so **all typography adapts automatically**.
- **`VyraApp`** resolves the brightness MaterialApp will display (light / dark / system→platform) and publishes it to `AppColors.brightness` *before* the themes build. Reading the platform brightness also rebuilds the app when the OS flips appearance.
- **`AppTheme`** now builds both themes from explicit per-brightness constants (construction never depends on the global) through a shared builder, and the **light theme is fully realized**: card elevation + soft shadow, navigation bar, dialog, bottom sheet, snackbar and switch theming.
- **Screens**: dropped `const` on the handful of decorations/icons that referenced the now-dynamic tokens. No structural UI changes.

Result: Settings → Dark / Light / Auto retints the **entire** app, instantly.

## Note on overlap with #8 / #12
This PR changes shared tokens to getters, so it touches `chat_screen.dart` and `vision_screen.dart` (only to drop `const`). PRs #15 (chat history) and #13 (camera/mic) also modify those files — expect a trivial merge resolution there. Any screen added by those PRs should use the brightness-aware tokens (which it already does via `AppColors`/`AppTextStyles`); just avoid `const` on a `BoxDecoration` that uses `AppColors.backgroundGradient`.

## Test plan
- [ ] Settings → Light: canvas, cards, text, nav bar and dialogs all switch to light and remain legible.
- [ ] Settings → Dark: unchanged signature dark look.
- [ ] Settings → Auto: follows the OS; flipping system appearance live re-tints the app.
- [ ] Chat, Assistant, Home, Onboarding, Settings, Vision all readable in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)