### PR TITLE
fix(build): unblock prod APK — record_linux override + compileSdk 36

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -10,7 +10,10 @@ plugins {
 
 android {
     namespace = "com.example.vyra"
-    compileSdk = flutter.compileSdkVersion
+    // flutter.compileSdkVersion is 35 on Flutter 3.29, but flutter_tts now
+    // compiles against SDK 36 (backward compatible; the CI build log asks
+    // for exactly this bump).
+    compileSdk = 36
     ndkVersion = "27.0.12077973"
 
     compileOptions {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,6 +59,13 @@ dependencies:
   uuid: ^4.5.1
   equatable: ^2.0.7
 
+# record 5.2.1 resolves record_linux 0.7.2, which is broken against
+# record_platform_interface 1.6.0 (missing startStream + old hasPermission
+# signature) and fails the release kernel compile on CI. record_linux 1.3.1
+# implements the current interface (accepts ^1.5.0, resolves fine with 1.6.0).
+dependency_overrides:
+  record_linux: 1.3.1
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## What broke

The post-merge **prod APK build** (Fastlane lane) failed at the release kernel compile with two independent issues:

### 1. `record_linux 0.7.2` is broken against its own platform interface ❌
`record 5.2.1` resolves `record_linux 0.7.2`, which never implemented `startStream` and has a stale `hasPermission` signature vs `record_platform_interface 1.6.0` → the whole kernel snapshot fails (even for an Android APK).

**Fix:** `dependency_overrides: record_linux: 1.3.1` — it implements the current interface, and its `^1.5.0` constraint resolves cleanly with `1.6.0`.

**Verified locally:** `flutter build bundle -t lib/main_prod.dart` reproduced the *exact* CI error before the override, and compiles a clean kernel after it. ✅

### 2. `flutter_tts` now compiles against Android SDK 36 ❌
The app pinned `flutter.compileSdkVersion` (35 on Flutter 3.29). Bumped `compileSdk = 36` in `android/app/build.gradle.kts` — exactly what the build log instructs; backward compatible, `minSdk`/`targetSdk` untouched.

## Verification

- `flutter build bundle -t lib/main_prod.dart` → clean kernel (was the failing step)
- `flutter analyze` → no issues
- `flutter test` → 18/18

Merging this should turn the prod lane green again. 🚀

🤖 Generated with [Claude Code](https://claude.com/claude-code)